### PR TITLE
Re-queue DigitalObjectImport if given parent is not found

### DIFF
--- a/db/migrate/20151223174138_add_requeue_count_to_digital_object_imports.rb
+++ b/db/migrate/20151223174138_add_requeue_count_to_digital_object_imports.rb
@@ -1,0 +1,5 @@
+class AddRequeueCountToDigitalObjectImports < ActiveRecord::Migration
+  def change
+    add_column :digital_object_imports, :requeue_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151202164848) do
+ActiveRecord::Schema.define(version: 20151223174138) do
 
   create_table "controlled_vocabularies", force: :cascade do |t|
     t.string   "string_key",             limit: 255
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20151202164848) do
     t.integer  "import_job_id",         limit: 4,                 null: false
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
+    t.integer  "requeue_count",         limit: 4,     default: 0, null: false
   end
 
   add_index "digital_object_imports", ["import_job_id"], name: "index_digital_object_imports_on_import_job_id", using: :btree

--- a/spec/jobs/process_digital_object_import_job_spec.rb
+++ b/spec/jobs/process_digital_object_import_job_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ProcessDigitalObjectImportJob, :type => :job do
+
+  before(:context) do
+
+    @test_pid_generator = PidGenerator.create!(id: 2015, namespace: 'spectest')
+    # create project to match project used in fixture
+    @test_project = Project.create!(id: 2015, string_key: 'the_project', display_label: 'projectname.001.1', pid_generator: @test_pid_generator)
+    @test_user = User.find_by_first_name('Test')
+    @test_import_job = ImportJob.create!(id: 2015, name: 'Test Import Job', user: @test_user)
+    @test_digital_object_import = DigitalObjectImport.create!(id: 2015, import_job: @test_import_job)
+    @digital_object_data_as_ruby_struct = JSON.parse( fixture('lib/hyacinth/utils/csv_import_export/csv_to_json/new_asset_example.json').read ) 
+
+  end
+
+  after(:context) do
+
+    @test_digital_object_import.destroy
+    @test_import_job.destroy
+    @test_project.destroy
+    @test_pid_generator.destroy
+
+      
+  end
+
+  context "#perform" do
+
+    current_resque_inline_value = Resque.inline
+
+    Resque.inline = true
+    max_requeues = ProcessDigitalObjectImportJob::MAX_REQUEUES
+
+    # doi is shorthand for DigitalObjectImport
+    it "requeue_count equal to #{max_requeues + 1} for doi with nonexistent parent" do
+
+      local_test_digital_object_import = @test_digital_object_import
+      local_test_digital_object_import.digital_object_data = 
+        ActiveSupport::JSON.encode @digital_object_data_as_ruby_struct
+      local_test_digital_object_import.save!
+
+      ProcessDigitalObjectImportJob::perform local_test_digital_object_import.id
+      local_test_digital_object_import.reload
+      Hyacinth::Utils::Logger.logger.debug "****** #{self.class.name} #{local_test_digital_object_import.requeue_count}"
+
+      expect(local_test_digital_object_import.requeue_count).to eq(max_requeues+1)
+
+    end
+
+  end
+
+end

--- a/spec/models/digital_object_import_spec.rb
+++ b/spec/models/digital_object_import_spec.rb
@@ -127,4 +127,21 @@ RSpec.describe DigitalObjectImport, :type => :model do
 
   end
 
+  context "attribute requeue_count :" do
+    
+    it "is initialized to 0" do
+
+      expect(@test_digital_object_import.requeue_count).to eq(0)
+
+    end
+
+    it "is incremented" do
+
+      @test_digital_object_import.requeue_count += 1
+      expect(@test_digital_object_import.requeue_count).to eq(1)
+
+    end
+    
+  end
+
 end


### PR DESCRIPTION
The parent of a Digital Object can be specified at the time of import.
However, if the specified parent is not found, the Digital Object
cannot be imported. However, it is possible that the parent Digital
Object is in the queue, ready to be imported, but has not yet been
processed. Therefore, the child Digital Object will be re-queued,
thus allowing the parent Digital Object to be processed before the
re-queued child Digital Object.
Digital Objects can be re-queued at most MAX_REQUEUES=3 times
Note that DigitalObjectImport instances are used to represent the
Digital Objects waiting to be imported.