### PR TITLE
Hyacinth 152 - Hide menus based on permissions when viewing an item

### DIFF
--- a/app/assets/templates/digital_objects_app/digital_objects/manage_children.ejs
+++ b/app/assets/templates/digital_objects_app/digital_objects/manage_children.ejs
@@ -3,7 +3,7 @@
   //
   //digitalObject
 %>
-<% Hyacinth.ContextualNav.setNavTitle('&laquo; Leave Child Management', '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'show', pid: Hyacinth.DigitalObjectsApp.params['pid']})); %>
+<% Hyacinth.ContextualNav.setNavTitle('&laquo; Back to Parent', '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'show', pid: Hyacinth.DigitalObjectsApp.params['pid']})); %>
 <% Hyacinth.ContextualNav.setNavItems([]); %>
 
 <div id="digital-object-ordered-child-editor"></div>

--- a/app/assets/templates/digital_objects_app/digital_objects/show.ejs
+++ b/app/assets/templates/digital_objects_app/digital_objects/show.ejs
@@ -16,22 +16,39 @@
 
 var navItems = [];
 
-if (digitalObject.digital_object_type.string_key == 'item') {
-  if (digitalObject.getOrderedChildDigitalObjectPids().length > 0) {
-    navItems.push({label: 'Manage Child Assets', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'manage_children', pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-  }
-  navItems.push({label: 'New Child Asset', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'upload_assets', parent_digital_object_pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-} else if (digitalObject.digital_object_type.string_key == 'group') {
-  if (digitalObject.getOrderedChildDigitalObjectPids().length > 0) {
-    navItems.push({label: 'Manage Children', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'manage_children', pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-  }
-  navItems.push({label: 'New Child', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'new_setup', project_string_key: digitalObject.getProject()['string_key'], parent_digital_object_pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-}
-
-navItems.push({label: 'Manage Parents', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'manage_parents', pid: Hyacinth.DigitalObjectsApp.params['pid']})});
-
 if (Hyacinth.DigitalObjectsApp.currentUser.hasProjectPermission(digitalObject.getProject()['pid'], 'can_update')) {
-  navItems.push({label: 'Edit', url: '#' + Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'edit', pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+  if (digitalObject.digital_object_type.string_key == 'item') {
+    if (digitalObject.getOrderedChildDigitalObjectPids().length > 0) {
+      navItems.push({label: 'Manage Child Assets', url: '#' + 
+                     Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                  action: 'manage_children',
+                                                                  pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+    }
+    navItems.push({label: 'New Child Asset', url: '#' + 
+                   Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                 action: 'upload_assets',
+                                                                 parent_digital_object_pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+  } else if (digitalObject.digital_object_type.string_key == 'group') {
+    if (digitalObject.getOrderedChildDigitalObjectPids().length > 0) {
+      navItems.push({label: 'Manage Children', url: '#' + 
+                     Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                   action: 'manage_children',
+                                                                   pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+    }
+    navItems.push({label: 'New Child', url: '#' + 
+                   Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                                 action: 'new_setup',
+                                                                 project_string_key: digitalObject.getProject()['string_key'],
+                                                                 parent_digital_object_pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+  }
+  navItems.push({label: 'Manage Parents', url: '#' + 
+                 Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                               action: 'manage_parents',
+                                                               pid: Hyacinth.DigitalObjectsApp.params['pid']})});
+  navItems.push({label: 'Edit', url: '#' + 
+                 Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects',
+                                                               action: 'edit',
+                                                               pid: Hyacinth.DigitalObjectsApp.params['pid']})});
 }
 
 %>

--- a/app/assets/templates/digital_objects_app/widgets/digital_object_ordered_child_editor/index.ejs
+++ b/app/assets/templates/digital_objects_app/widgets/digital_object_ordered_child_editor/index.ejs
@@ -11,7 +11,7 @@
 <strong>PID:</strong> <%= digitalObject.getPid() %>
 <hr />
 
-<h2 class="manage-children-heading">Manage Child Digital Objects</h2>
+<h2 class="manage-children-heading">Child Digital Objects</h2>
 
 <p><%= orderedChildDigitalObjects.length %> Children Total</p>
 
@@ -27,12 +27,19 @@
   <% orderedChildDigitalObjects.forEach(function(childDigitalObject){ %>
     <div class="ordered-child shadow-box" data-pid="<%= childDigitalObject.getPid() %>">
       <div class="row">
+  <% if(Hyacinth.DigitalObjectsApp.currentUser.hasProjectPermission(digitalObject.getProject()['pid'], 'can_update')) { %>
         <div class="col-xs-2">
           <button class="btn btn-default btn-sm shift-child-up"><span class="glyphicon glyphicon-arrow-up"></span></button>
           <br />
           <button class="btn btn-default btn-sm shift-child-down"><span class="glyphicon glyphicon-arrow-down"></span></button>
         </div>
+  <% } %>
+  <% if(Hyacinth.DigitalObjectsApp.currentUser.hasProjectPermission(digitalObject.getProject()['pid'], 'can_update')) { %>
         <div class="col-xs-8">
+  <% } else { %>
+        <div class="col-xs-10">
+  <% } %>
+  
             <strong>PID:</strong> <a href="#<%= Hyacinth.DigitalObjectsApp.paramsToHashValue({controller: 'digital_objects', action: 'show', pid: childDigitalObject.getPid()}) %>"><%= childDigitalObject.getPid() %></a>
             <br />
             <strong>Title: <%- childDigitalObject.getTitle() %></strong>


### PR DESCRIPTION
The following menus show up when a user with read-only permission on a project is viewing an Item:
-) Manage Child Assets
-) New Child Asset
-) Manage Parents
These menus should be hidden if the user does not have the proper permissions.